### PR TITLE
normalize grads option instead of trust region, defaults

### DIFF
--- a/heavyball/cached_delayed_psgd_kron.py
+++ b/heavyball/cached_delayed_psgd_kron.py
@@ -9,7 +9,7 @@ from typing import Optional
 import torch
 from heavyball.utils import min_dtype, precond_grad_cached_
 
-from .utils import update_param_, warmup, init_Q_exprs, normalize_grads_, PSGDBase,  \
+from .utils import update_param_, warmup, init_Q_exprs, trust_region_clip_, normalize_grads_, PSGDBase,  \
     line_to_triu, triu_to_line, einsum_base, promote, stochastic_lerp_, beta_debias, precond_grad_cached_
 
 
@@ -54,6 +54,9 @@ class ForeachCachedDelayedPSGDKron(PSGDBase):
             raise ValueError(f"Invalid beta parameter: {beta}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
+
+        if clip_fn is None:
+            clip_fn = lambda x: trust_region_clip_(x, 0.9, 1.5)
 
         defaults = dict(lr=lr, beta=beta, normalize_grads=normalize_grads, weight_decay=weight_decay,
                         max_size_triangular=max_size_triangular, min_ndim_triangular=min_ndim_triangular,

--- a/heavyball/cached_delayed_psgd_kron.py
+++ b/heavyball/cached_delayed_psgd_kron.py
@@ -9,7 +9,7 @@ from typing import Optional
 import torch
 from heavyball.utils import min_dtype, precond_grad_cached_
 
-from .utils import update_param_, warmup, init_Q_exprs, trust_region_clip_, PSGDBase,  \
+from .utils import update_param_, warmup, init_Q_exprs, normalize_grads_, PSGDBase,  \
     line_to_triu, triu_to_line, einsum_base, promote, stochastic_lerp_, beta_debias, precond_grad_cached_
 
 
@@ -23,6 +23,7 @@ class ForeachCachedDelayedPSGDKron(PSGDBase):
             parameter groups.
         lr (float): Learning rate.
         beta (float): Momentum parameter.
+        normalize_grads (bool): Whether to normalize incoming gradients to unit norm layer-wise.
         weight_decay (float): Weight decay (L2 penalty).
         preconditioner_update_probability (callable or float, optional): Probability of
             updating the preconditioner. If None, defaults to a schedule that anneals
@@ -38,11 +39,11 @@ class ForeachCachedDelayedPSGDKron(PSGDBase):
             update instead of raw gradients.
     """
 
-    def __init__(self, params, lr=0.001, beta=0.9, weight_decay=0.0, preconditioner_update_probability=None,
-                 max_size_triangular=2048, min_ndim_triangular=2, memory_save_mode=None,
-                 momentum_into_precond_update=True, warmup_steps: int = 1, merge_dims: bool = False,
+    def __init__(self, params, lr=0.001, beta=0.9, normalize_grads=False, weight_decay=0.0,
+                 preconditioner_update_probability=None, max_size_triangular=8192, min_ndim_triangular=2,
+                 memory_save_mode=None, momentum_into_precond_update=True, warmup_steps: int = 1, merge_dims: bool = False,
                  split: bool = False, clip_fn: Optional[callable] = None, store_triu_as_line: bool = True,
-                 foreach: bool = True, q_dtype='float32', stochastic_schedule: bool = True,
+                 foreach: bool = True, q_dtype='float32', stochastic_schedule: bool = False,
                  storage_dtype: str = 'float32', mars: bool = False, caution: bool = False, mars_gamma: float = 0.0025,
                  #
                  # expert parameters
@@ -54,14 +55,11 @@ class ForeachCachedDelayedPSGDKron(PSGDBase):
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
 
-        if clip_fn is None:
-            clip_fn = lambda x: trust_region_clip_(x, 0.9, 1.5)
-
-        defaults = dict(lr=lr, beta=beta, weight_decay=weight_decay, max_size_triangular=max_size_triangular,
-                        min_ndim_triangular=min_ndim_triangular, memory_save_mode=memory_save_mode,
-                        momentum_into_precond_update=momentum_into_precond_update, precond_lr=precond_lr,
-                        precond_init_scale=precond_init_scale, step=0, warmup_steps=warmup_steps, merge_dims=merge_dims,
-                        split=split, store_triu_as_line=store_triu_as_line, q_dtype=q_dtype,
+        defaults = dict(lr=lr, beta=beta, normalize_grads=normalize_grads, weight_decay=weight_decay,
+                        max_size_triangular=max_size_triangular, min_ndim_triangular=min_ndim_triangular,
+                        memory_save_mode=memory_save_mode, momentum_into_precond_update=momentum_into_precond_update,
+                        precond_lr=precond_lr, precond_init_scale=precond_init_scale, step=0, warmup_steps=warmup_steps,
+                        merge_dims=merge_dims, split=split, store_triu_as_line=store_triu_as_line, q_dtype=q_dtype,
                         storage_dtype=storage_dtype, caution=caution, mars_gamma=mars_gamma, mars=mars)
         super().__init__(params, defaults, foreach, stochastic_schedule, clip_fn, preconditioner_update_probability)
 
@@ -76,6 +74,7 @@ class ForeachCachedDelayedPSGDKron(PSGDBase):
         weight_decay = group['weight_decay']
         lr = group['lr']
         beta = group['beta']
+        normalize_grads = group['normalize_grads']
         store_triu_as_line = group['store_triu_as_line']
         q_dtype = getattr(torch, group['q_dtype'])
         storage_dtype = getattr(torch, group['storage_dtype'])
@@ -109,6 +108,9 @@ class ForeachCachedDelayedPSGDKron(PSGDBase):
         del vals
 
         group["step"] += 1
+
+        if normalize_grads:
+            grad_list = normalize_grads_(grad_list)
 
         stochastic_lerp_(exp_avg_list, grad_list, 1 - beta_debias(beta, group['step']))
 

--- a/heavyball/cached_psgd_kron.py
+++ b/heavyball/cached_psgd_kron.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import torch
 
-from .utils import update_param_, warmup, init_Q_exprs, trust_region_clip_, PSGDBase, \
+from .utils import update_param_, warmup, init_Q_exprs, normalize_grads_, PSGDBase, \
     line_to_triu, triu_to_line, einsum_base, promote, stochastic_lerp_, beta_debias, precond_grad_cached_
 
 
@@ -20,6 +20,7 @@ class ForeachCachedPSGDKron(PSGDBase):
             parameter groups.
         lr (float): Learning rate.
         beta (float): Momentum parameter.
+        normalize_grads (bool): Whether to normalize incoming gradients to unit norm layer-wise.
         weight_decay (float): Weight decay (L2 penalty).
         preconditioner_update_probability (callable or float, optional): Probability of
             updating the preconditioner. If None, defaults to a schedule that anneals
@@ -35,11 +36,11 @@ class ForeachCachedPSGDKron(PSGDBase):
             update instead of raw gradients.
     """
 
-    def __init__(self, params, lr=0.001, beta=0.9, weight_decay=0.0, preconditioner_update_probability=None,
-                 max_size_triangular=2048, min_ndim_triangular=2, memory_save_mode=None,
-                 momentum_into_precond_update=True, warmup_steps: int = 1, merge_dims: bool = False,
+    def __init__(self, params, lr=0.001, beta=0.9, normalize_grads=False, weight_decay=0.0,
+                 preconditioner_update_probability=None, max_size_triangular=8192, min_ndim_triangular=2,
+                 memory_save_mode=None, momentum_into_precond_update=True, warmup_steps: int = 1, merge_dims: bool = False,
                  split: bool = False, clip_fn: Optional[callable] = None, store_triu_as_line: bool = True,
-                 foreach: bool = True, q_dtype='float32', stochastic_schedule: bool = True,
+                 foreach: bool = True, q_dtype='float32', stochastic_schedule: bool = False,
                  storage_dtype: str = 'float32', mars: bool = False, caution: bool = False, mars_gamma: float = 0.0025,
                  #
                  # expert parameters
@@ -51,14 +52,12 @@ class ForeachCachedPSGDKron(PSGDBase):
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
 
-        if clip_fn is None:
-            clip_fn = lambda x: trust_region_clip_(x, 0.9, 1.5)
-
-        defaults = dict(lr=lr, beta=beta, weight_decay=weight_decay, max_size_triangular=max_size_triangular,
-                        min_ndim_triangular=min_ndim_triangular, memory_save_mode=memory_save_mode,
-                        momentum_into_precond_update=momentum_into_precond_update, precond_lr=precond_lr,
-                        precond_init_scale=precond_init_scale, step=0, warmup_steps=warmup_steps, merge_dims=merge_dims,
-                        split=split, store_triu_as_line=store_triu_as_line, q_dtype=q_dtype,
+        defaults = dict(lr=lr, beta=beta, normalize_grads=normalize_grads, weight_decay=weight_decay,
+                        max_size_triangular=max_size_triangular, min_ndim_triangular=min_ndim_triangular,
+                        memory_save_mode=memory_save_mode, momentum_into_precond_update=momentum_into_precond_update,
+                        precond_lr=precond_lr, precond_init_scale=precond_init_scale, step=0,
+                        warmup_steps=warmup_steps, merge_dims=merge_dims, split=split,
+                        store_triu_as_line=store_triu_as_line, q_dtype=q_dtype,
                         storage_dtype=storage_dtype, caution=caution, mars_gamma=mars_gamma, mars=mars)
         super().__init__(params, defaults, foreach, stochastic_schedule, clip_fn, preconditioner_update_probability)
 
@@ -72,6 +71,7 @@ class ForeachCachedPSGDKron(PSGDBase):
         weight_decay = group['weight_decay']
         lr = group['lr']
         beta = group['beta']
+        normalize_grads = group['normalize_grads']
         store_triu_as_line = group['store_triu_as_line']
         q_dtype = getattr(torch, group['q_dtype'])
         storage_dtype = getattr(torch, group['storage_dtype'])
@@ -106,6 +106,9 @@ class ForeachCachedPSGDKron(PSGDBase):
         del vals
 
         group["step"] += 1
+
+        if normalize_grads:
+            grad_list = normalize_grads_(grad_list)
 
         stochastic_lerp_(exp_avg_list, grad_list, 1 - beta_debias(beta, group['step']))
 

--- a/heavyball/cached_psgd_kron.py
+++ b/heavyball/cached_psgd_kron.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import torch
 
-from .utils import update_param_, warmup, init_Q_exprs, normalize_grads_, PSGDBase, \
+from .utils import update_param_, warmup, init_Q_exprs, trust_region_clip_, normalize_grads_, PSGDBase, \
     line_to_triu, triu_to_line, einsum_base, promote, stochastic_lerp_, beta_debias, precond_grad_cached_
 
 
@@ -51,6 +51,9 @@ class ForeachCachedPSGDKron(PSGDBase):
             raise ValueError(f"Invalid beta parameter: {beta}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
+
+        if clip_fn is None:
+            clip_fn = lambda x: trust_region_clip_(x, 0.9, 1.5)
 
         defaults = dict(lr=lr, beta=beta, normalize_grads=normalize_grads, weight_decay=weight_decay,
                         max_size_triangular=max_size_triangular, min_ndim_triangular=min_ndim_triangular,

--- a/heavyball/delayed_psgd.py
+++ b/heavyball/delayed_psgd.py
@@ -7,8 +7,8 @@ Source available at https://github.com/evanatyourservice/kron_torch/blob/97a2b5e
 import torch
 from heavyball.utils import stochastic_lerp_, beta_debias, stochastic_add_
 
-from .utils import update_param_, warmup, psgd_precond_grad, init_Q_exprs, normalize_grads_, PSGDBase, \
-    triu_to_line, line_to_triu, promote,_compilable_update_, decorator_knowngood
+from .utils import update_param_, warmup, psgd_precond_grad, init_Q_exprs, trust_region_clip_, normalize_grads_, \
+    PSGDBase, triu_to_line, line_to_triu, promote,_compilable_update_, decorator_knowngood
 
 
 @decorator_knowngood
@@ -56,6 +56,9 @@ class ForeachDelayedPSGD(PSGDBase):
             raise ValueError(f"Invalid beta parameter: {beta}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
+
+        if clip_fn is None:
+            clip_fn = lambda x: trust_region_clip_(x, 0.9, 1.5)
 
         defaults = dict(lr=lr, beta=beta, normalize_grads=normalize_grads, weight_decay=weight_decay,
                         max_size_triangular=max_size_triangular, min_ndim_triangular=min_ndim_triangular,

--- a/heavyball/psgd_kron.py
+++ b/heavyball/psgd_kron.py
@@ -8,8 +8,8 @@ from typing import Optional
 
 import torch
 
-from .utils import update_param_, warmup, psgd_precond_grad, init_Q_exprs, normalize_grads_, PSGDBase, \
-    line_to_triu, triu_to_line, promote, stochastic_lerp_, beta_debias
+from .utils import update_param_, warmup, psgd_precond_grad, init_Q_exprs, trust_region_clip_, normalize_grads_, \
+    PSGDBase, line_to_triu, triu_to_line, promote, stochastic_lerp_, beta_debias
 
 
 class ForeachPSGDKron(PSGDBase):
@@ -51,6 +51,9 @@ class ForeachPSGDKron(PSGDBase):
             raise ValueError(f"Invalid beta parameter: {beta}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
+
+        if clip_fn is None:
+            clip_fn = lambda x: trust_region_clip_(x, 0.9, 1.5)
 
         defaults = dict(lr=lr, beta=beta, normalize_grads=normalize_grads, weight_decay=weight_decay,
                         max_size_triangular=max_size_triangular, min_ndim_triangular=min_ndim_triangular,

--- a/heavyball/psgd_kron.py
+++ b/heavyball/psgd_kron.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import torch
 
-from .utils import update_param_, warmup, psgd_precond_grad, init_Q_exprs, trust_region_clip_, PSGDBase, \
+from .utils import update_param_, warmup, psgd_precond_grad, init_Q_exprs, normalize_grads_, PSGDBase, \
     line_to_triu, triu_to_line, promote, stochastic_lerp_, beta_debias
 
 
@@ -20,6 +20,7 @@ class ForeachPSGDKron(PSGDBase):
             parameter groups.
         lr (float): Learning rate.
         b1 (float): Momentum parameter.
+        normalize_grads (bool): Whether to normalize incoming gradients to unit norm layer-wise.
         weight_decay (float): Weight decay (L2 penalty).
         preconditioner_update_probability (callable or float, optional): Probability of
             updating the preconditioner. If None, defaults to a schedule that anneals
@@ -35,11 +36,11 @@ class ForeachPSGDKron(PSGDBase):
             update instead of raw gradients.
     """
 
-    def __init__(self, params, lr=0.001, beta=0.9, weight_decay=0.0, preconditioner_update_probability=None,
-                 max_size_triangular=2048, min_ndim_triangular=2, memory_save_mode=None,
-                 momentum_into_precond_update=True, warmup_steps: int = 1, merge_dims: bool = False,
+    def __init__(self, params, lr=0.001, beta=0.9, normalize_grads=False, weight_decay=0.0,
+                 preconditioner_update_probability=None, max_size_triangular=8192, min_ndim_triangular=2,
+                 memory_save_mode=None, momentum_into_precond_update=True, warmup_steps: int = 1, merge_dims: bool = False,
                  split: bool = False, clip_fn: Optional[callable] = None, store_triu_as_line: bool = True,
-                 foreach: bool = True, q_dtype='float32', stochastic_schedule: bool = True,
+                 foreach: bool = True, q_dtype='float32', stochastic_schedule: bool = False,
                  storage_dtype: str = 'float32', mars: bool = False, caution: bool = False, mars_gamma: float = 0.0025,
                  #
                  # expert parameters
@@ -51,14 +52,11 @@ class ForeachPSGDKron(PSGDBase):
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
 
-        if clip_fn is None:
-            clip_fn = lambda x: trust_region_clip_(x, 0.9, 1.5)
-
-        defaults = dict(lr=lr, beta=beta, weight_decay=weight_decay, max_size_triangular=max_size_triangular,
-                        min_ndim_triangular=min_ndim_triangular, memory_save_mode=memory_save_mode,
-                        momentum_into_precond_update=momentum_into_precond_update, precond_lr=precond_lr,
-                        precond_init_scale=precond_init_scale, step=0, warmup_steps=warmup_steps, merge_dims=merge_dims,
-                        split=split, store_triu_as_line=store_triu_as_line, q_dtype=q_dtype,
+        defaults = dict(lr=lr, beta=beta, normalize_grads=normalize_grads, weight_decay=weight_decay,
+                        max_size_triangular=max_size_triangular, min_ndim_triangular=min_ndim_triangular,
+                        memory_save_mode=memory_save_mode, momentum_into_precond_update=momentum_into_precond_update,
+                        precond_lr=precond_lr, precond_init_scale=precond_init_scale, step=0, warmup_steps=warmup_steps,
+                        merge_dims=merge_dims, split=split, store_triu_as_line=store_triu_as_line, q_dtype=q_dtype,
                         storage_dtype=storage_dtype,
                         mars=mars, caution=caution, mars_gamma=mars_gamma)
         super().__init__(params, defaults, foreach, stochastic_schedule, clip_fn, preconditioner_update_probability)
@@ -74,6 +72,7 @@ class ForeachPSGDKron(PSGDBase):
         weight_decay = group['weight_decay']
         lr = group['lr']
         beta = group['beta']
+        normalize_grads = group['normalize_grads']
         store_triu_as_line = group['store_triu_as_line']
         q_dtype = getattr(torch, group['q_dtype'])
         storage_dtype = getattr(torch, group['storage_dtype'])
@@ -98,6 +97,9 @@ class ForeachPSGDKron(PSGDBase):
         del vals
 
         group["step"] += 1
+
+        if normalize_grads:
+            normalize_grads_(grad_list)
 
         beta = beta_debias(beta, group["step"])
         beta = torch.empty((), dtype=torch.float32, device=grad_list[0].device).fill_(1 - beta)

--- a/heavyball/pure_psgd.py
+++ b/heavyball/pure_psgd.py
@@ -48,6 +48,9 @@ class ForeachPurePSGD(PSGDBase):
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
 
+        if clip_fn is None:
+            clip_fn = identity
+
         assert not mars, "MARS is not supported in this optimizer"
 
         defaults = dict(lr=lr, normalize_grads=normalize_grads, weight_decay=weight_decay,

--- a/heavyball/utils.py
+++ b/heavyball/utils.py
@@ -927,6 +927,13 @@ def norm_clip_(x, scale=None):
     return x
 
 
+def normalize_grads_(x, eps=1e-12):
+    norm = torch._foreach_norm(x)
+    torch._foreach_add_(norm, eps)
+    torch._foreach_div_(x, norm)
+    return x
+
+
 def mu_law_compress(x, mu=127.0):
     """
     Foreach version of https://github.com/opooladz/modded-nanogpt-psgd/blob/dc7c78082ac15fbf326f1bacd9e0ead0a2b45908/kron_mu.py
@@ -1096,7 +1103,7 @@ def caution(g, update):
     _compilable_cautioning_(g, update)
 
 
-def precond_update_prob_schedule(max_prob=1.0, min_prob=0.03, decay=0.001, flat_start=250):
+def precond_update_prob_schedule(max_prob=1.0, min_prob=0.03, decay=0.001, flat_start=500):
     """Anneal preconditioner update probability during beginning of training.
 
     PSGD benefits from more preconditioner updates at the beginning of training,

--- a/heavyball/utils.py
+++ b/heavyball/utils.py
@@ -919,10 +919,12 @@ def psgd_precond_grad(inplace: bool, exprs: str, grad: Tensor, *preconds: Tensor
     return out.to(grad.dtype)
 
 
-def norm_clip_(x, scale=None):
-    norm = torch._foreach_norm(x)
+def norm_clip_(x, scale=None, eps=1e-12):
+    norm = [a.square_().mean_() for a in x]
+    torch._foreach_sqrt_(norm)
     if scale is not None:
         torch._foreach_div_(norm, scale)
+    torch._foreach_add_(norm, eps)
     torch._foreach_div_(x, norm)
     return x
 


### PR DESCRIPTION
overall changes:

- switch default flat start for update prob schedule in utils.py
- normalize_grads replaces trust region clipping (let it default to identity in PSGDBase)
- change some defaults (max size triangular -> 8192, stochastic=False for krons with momentum)

The main thing is moving away from trust region clipping on outgoing updates and opting for optionally controlling incoming grads instead. This also allows the user more control over this as they can clip grads as they see fit before the optimizer.