### PR TITLE
Add damping to preconditioner update for stability

### DIFF
--- a/heavyball/utils.py
+++ b/heavyball/utils.py
@@ -983,14 +983,14 @@ def psgd_balance_Q(Q_in):
 
 
 def psgd_calc_A_and_conjB(exprA, G, Q):
-    V = torch.randn(G.shape, dtype=promote(G.dtype), device=G.device)
-    # damp G based on machine precision (f32 is enough)
-    G += torch.sqrt(torch.finfo(torch.float32).eps) * torch.mean(torch.abs(G)) * V
+    V = torch.randn(G.shape, dtype=G.dtype, device=G.device)
+    eps = torch.tensor(torch.sqrt(torch.finfo(torch.float32).eps), dtype=G.dtype, device=G.device)
+    G += eps * torch.mean(torch.abs(G)) * V
     md = min_dtype(Q + [G])
     A = torch.einsum(exprA, *[q.to(md) for q in Q], G.to(md)).to(G.dtype)
     order = G.dim()
     p = list(range(order))
-    conjB = torch.permute(V, p[1:] + p[:1])
+    conjB = torch.permute(V, p[1:] + p[:1]).to(promote(G.dtype))
     Q = [promote(q) for q in Q]
     for i, q in enumerate(Q):
         if q.dim() <= 1:


### PR DESCRIPTION
Adding damping based on machine precision to properly handle when g g ^ T is singular or near-singular. Float32 epsilon seems to be enough for both f32 and bf16 in practice and is a good choice for now (rare that gradients are ill-conditioned enough to necessitate higher in online setting when preconditioner LR < 1).